### PR TITLE
Dev

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -12,6 +12,7 @@ permissions:
   statuses: write
   issues: write
   discussions: write
+  id-token: write
 
 jobs:
   Build-Dist:


### PR DESCRIPTION
This pull request adds a new permission to the GitHub Actions workflow configuration file. The change grants `id-token` write access, which is typically used for authentication purposes in workflows.